### PR TITLE
Remove redundant notification call and fix copy message

### DIFF
--- a/scripts/copiar.js
+++ b/scripts/copiar.js
@@ -4,7 +4,7 @@ botonCopiar.addEventListener("click", () => {
     const texto = document.getElementById("textarea_dos").value.trim();
 
     if (texto === "") {
-        mostrarNotificacion("El campo estqa vacio")
+        mostrarNotificacion("El campo está vacío");
         return;
     }
 

--- a/scripts/encriptar.js
+++ b/scripts/encriptar.js
@@ -30,10 +30,9 @@ function desencriptar(texto) {
 function procesar(texto, accion) {
     if (texto.trim() === "") {
         console.log("No ingresaste ningún texto"); // Usando console.log en lo que estan listas las notificaciones
-        mostrarNotificacion();
         mostrarNotificacion("No ingresaste ningún texto");
         return "";
-    } else
+    }
     return accion === "encriptar" ? encriptar(texto) : desencriptar(texto);
 }
 


### PR DESCRIPTION
## Summary
- Avoid undefined notifications by removing extra `mostrarNotificacion` call
- Fix typo in empty-field message when copying text

## Testing
- `node --check scripts/encriptar.js`
- `node --check scripts/copiar.js`
- `npx --yes eslint scripts/encriptar.js scripts/copiar.js` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a206166cb083208df4d65887a12ed8